### PR TITLE
Add setuptools configuration

### DIFF
--- a/scripts/assess_predictions.py
+++ b/scripts/assess_predictions.py
@@ -26,7 +26,7 @@ from loguru import logger
 logger = misc.format_logger(logger)
 
 
-if __name__ == '__main__':
+def main():
 
     tic = time.time()
     logger.info('Starting...')
@@ -298,3 +298,8 @@ if __name__ == '__main__':
     logger.success(f"Nothing left to be done: exiting. Elapsed time: {(toc-tic):.2f} seconds")
 
     sys.stderr.flush()
+
+
+if __name__ == "__main__":
+
+    main()

--- a/scripts/assess_predictions.py
+++ b/scripts/assess_predictions.py
@@ -26,18 +26,14 @@ from loguru import logger
 logger = misc.format_logger(logger)
 
 
-def main():
+def main(cfg_file_path):
 
     tic = time.time()
     logger.info('Starting...')
 
-    parser = argparse.ArgumentParser(description="This script assesses the quality of predictions with respect to ground-truth/other labels.")
-    parser.add_argument('config_file', type=str, help='a YAML config file')
-    args = parser.parse_args()
+    logger.info(f"Using {cfg_file_path} as config file.")
 
-    logger.info(f"Using {args.config_file} as config file.")
-
-    with open(args.config_file) as fp:
+    with open(cfg_file_path) as fp:
         cfg = yaml.load(fp, Loader=yaml.FullLoader)[os.path.basename(__file__)]
 
     OUTPUT_DIR = cfg['output_folder']
@@ -302,4 +298,10 @@ def main():
 
 if __name__ == "__main__":
 
-    main()
+    parser = argparse.ArgumentParser(description="This script assesses the quality of predictions with respect to ground-truth/other labels.")
+    parser.add_argument('config_file', type=str, help='a YAML config file')
+    args = parser.parse_args()
+
+    main(args.config_file)
+
+    

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,0 +1,49 @@
+# see https://realpython.com/command-line-interfaces-python-argparse/#adding-subcommands-to-your-clis
+
+import argparse
+from scripts.generate_tilesets import main as generate_tilesets
+from scripts.train_model import main as train_model
+from scripts.make_predictions import main as make_predictions
+from scripts.assess_predictions import main as assess_predictions
+
+
+def main():
+
+    global_parser = argparse.ArgumentParser(prog="stdl-objdet")
+
+    subparsers = global_parser.add_subparsers(
+        title="tasks", help="the various tasks which can be performed by the STDL Object Detector"
+    )
+
+    arg_template = {
+        "dest": "operands",
+        "type": str,
+        "nargs": 1,
+        "metavar": "<path_to_config_file.yaml>",
+        "help": "configuration file",
+    }
+
+    add_parser = subparsers.add_parser("generate_tilesets", help="This script generates COCO-annotated training/validation/test/other datasets for object detection tasks.")
+    add_parser.add_argument(**arg_template)
+    add_parser.set_defaults(func=generate_tilesets)
+
+    add_parser = subparsers.add_parser("train_model", help="This script trains a predictive model.")
+    add_parser.add_argument(**arg_template)
+    add_parser.set_defaults(func=train_model)
+
+    add_parser = subparsers.add_parser("make_predictions", help="This script makes predictions, using a previously trained model.")
+    add_parser.add_argument(**arg_template)
+    add_parser.set_defaults(func=make_predictions)
+
+    add_parser = subparsers.add_parser("assess_predictions", help="This script assesses the quality of predictions with respect to ground-truth/other labels.")
+    add_parser.add_argument(**arg_template)
+    add_parser.set_defaults(func=assess_predictions)
+
+    args = global_parser.parse_args()
+
+    args.func(*args.operands)
+
+
+if __name__ == "__main__":
+
+    main()

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,5 +1,5 @@
 # see https://realpython.com/command-line-interfaces-python-argparse/#adding-subcommands-to-your-clis
-
+import sys
 import argparse
 from scripts.generate_tilesets import main as generate_tilesets
 from scripts.train_model import main as train_model
@@ -39,7 +39,8 @@ def main():
     add_parser.add_argument(**arg_template)
     add_parser.set_defaults(func=assess_predictions)
 
-    args = global_parser.parse_args()
+    # https://stackoverflow.com/a/47440202
+    args = global_parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     args.func(*args.operands)
 

--- a/scripts/generate_tilesets.py
+++ b/scripts/generate_tilesets.py
@@ -128,18 +128,14 @@ def extract_xyz(aoi_tiles_gdf):
     return aoi_tiles_gdf.apply(_id_to_xyz, axis=1)
 
 
-def main():
+def main(cfg_file_path):
 
     tic = time.time()
     logger.info('Starting...')
 
-    parser = argparse.ArgumentParser(description="This script generates COCO-annotated training/validation/test/other datasets for object detection tasks.")
-    parser.add_argument('config_file', type=str, help='a YAML config file')
-    args = parser.parse_args()
+    logger.info(f"Using {cfg_file_path} as config file.")
 
-    logger.info(f"Using {args.config_file} as config file.")
-
-    with open(args.config_file) as fp:
+    with open(cfg_file_path) as fp:
         cfg = yaml.load(fp, Loader=yaml.FullLoader)[os.path.basename(__file__)]
 
     DEBUG_MODE = cfg['debug_mode']
@@ -558,4 +554,10 @@ def main():
 
 if __name__ == "__main__":
 
-    main()
+    parser = argparse.ArgumentParser(description="This script generates COCO-annotated training/validation/test/other datasets for object detection tasks.")
+    parser.add_argument('config_file', type=str, help='a YAML config file')
+    args = parser.parse_args()
+
+    main(args.config_file)
+
+    

--- a/scripts/generate_tilesets.py
+++ b/scripts/generate_tilesets.py
@@ -128,8 +128,7 @@ def extract_xyz(aoi_tiles_gdf):
     return aoi_tiles_gdf.apply(_id_to_xyz, axis=1)
 
 
-if __name__ == "__main__":
-
+def main():
 
     tic = time.time()
     logger.info('Starting...')
@@ -555,3 +554,8 @@ if __name__ == "__main__":
     logger.success(f"Nothing left to be done: exiting. Elapsed time: {(toc-tic):.2f} seconds")
 
     sys.stderr.flush()
+
+
+if __name__ == "__main__":
+
+    main()

--- a/scripts/make_predictions.py
+++ b/scripts/make_predictions.py
@@ -37,18 +37,14 @@ from loguru import logger
 logger = format_logger(logger)
 
 
-def main():
-    
+def main(cfg_file_path):
+
     tic = time.time()
     logger.info('Starting...')
 
-    parser = argparse.ArgumentParser(description="This script makes predictions, using a previously trained model.")
-    parser.add_argument('config_file', type=str, help='a YAML config file')
-    args = parser.parse_args()
+    logger.info(f"Using {cfg_file_path} as config file.")
 
-    logger.info(f"Using {args.config_file} as config file.")
-
-    with open(args.config_file) as fp:
+    with open(cfg_file_path) as fp:
         cfg = yaml.load(fp, Loader=yaml.FullLoader)[os.path.basename(__file__)]
         
     # ---- parse config file  
@@ -181,7 +177,13 @@ def main():
 
     sys.stderr.flush()
 
-
+    
 if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser(description="This script makes predictions, using a previously trained model.")
+    parser.add_argument('config_file', type=str, help='a YAML config file')
+    args = parser.parse_args()
 
-    main()
+    main(args.config_file)
+
+    

--- a/scripts/make_predictions.py
+++ b/scripts/make_predictions.py
@@ -37,7 +37,7 @@ from loguru import logger
 logger = format_logger(logger)
 
 
-if __name__ == "__main__":
+def main():
     
     tic = time.time()
     logger.info('Starting...')
@@ -182,3 +182,6 @@ if __name__ == "__main__":
     sys.stderr.flush()
 
 
+if __name__ == "__main__":
+
+    main()

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -32,18 +32,14 @@ from loguru import logger
 logger = format_logger(logger)
 
 
-def main():
-    
+def main(cfg_file_path):
+
     tic = time.time()
     logger.info('Starting...')
 
-    parser = argparse.ArgumentParser(description="This script trains a predictive models.")
-    parser.add_argument('config_file', type=str, help='a YAML config file')
-    args = parser.parse_args()
-
-    logger.info(f"Using {args.config_file} as config file.")
-
-    with open(args.config_file) as fp:
+    logger.info(f"Using {cfg_file_path} as config file.")
+    
+    with open(cfg_file_path) as fp:
         cfg = yaml.load(fp, Loader=yaml.FullLoader)[os.path.basename(__file__)]
         
     # ---- parse config file    
@@ -169,10 +165,15 @@ def main():
     logger.success(f"Nothing left to be done: exiting. Elapsed time: {(toc-tic):.2f} seconds")
 
     sys.stderr.flush()
-
+    
 
 if __name__ == "__main__":
 
-    main()
+    parser = argparse.ArgumentParser(description="This script trains a predictive model.")
+    parser.add_argument('config_file', type=str, help='a YAML config file')
+    args = parser.parse_args()
 
+    main(args.config_file)
+
+    
 

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -32,7 +32,7 @@ from loguru import logger
 logger = format_logger(logger)
 
 
-if __name__ == "__main__":
+def main():
     
     tic = time.time()
     logger.info('Starting...')
@@ -169,5 +169,10 @@ if __name__ == "__main__":
     logger.success(f"Nothing left to be done: exiting. Elapsed time: {(toc-tic):.2f} seconds")
 
     sys.stderr.flush()
+
+
+if __name__ == "__main__":
+
+    main()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
@@ -19,5 +19,7 @@ setup(
             'assess_predictions=scripts.assess_predictions:main',
             ]
     },
-    install_requires=requirements
+    install_requires=requirements,
+    packages=find_packages()
+    #package_dir = {'scripts': 'scripts'}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
+setup(
+    name='stdl-object-detector',
+    version='latest',
+    description='A suite of Python scripts allowing the end-user to use Deep Learning to detect objects in georeferenced raster images.',
+    author='Swiss Territorial Data Lab (STDL)',
+    author_email='info@stdl.ch',
+    python_requires=">=3.8",
+    license="MIT license",
+    entry_points = {
+        'console_scripts': [
+            'generate_tilesets=scripts.generate_tilesets:main',
+            'train_model=scripts.train_model:main',
+            'make_predictions=scripts.make_predictions:main',
+            'assess_predictions=scripts.assess_predictions:main',
+            ]
+    },
+    install_requires=requirements
+)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='stdl-object-detector',
-    version='latest',
+    version='1.0rc1.dev1',
     description='A suite of Python scripts allowing the end-user to use Deep Learning to detect objects in georeferenced raster images.',
     author='Swiss Territorial Data Lab (STDL)',
     author_email='info@stdl.ch',

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,7 @@ setup(
     license="MIT license",
     entry_points = {
         'console_scripts': [
-            'generate_tilesets=scripts.generate_tilesets:main',
-            'train_model=scripts.train_model:main',
-            'make_predictions=scripts.make_predictions:main',
-            'assess_predictions=scripts.assess_predictions:main',
+            'stdl-objdet=scripts.cli:main'
             ]
     },
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,4 @@ setup(
     },
     install_requires=requirements,
     packages=find_packages()
-    #package_dir = {'scripts': 'scripts'}
 )


### PR DESCRIPTION
The setuptools configuration, which can be found in the `setup.py` file, allows turning the object detector code base into a (more) proper Python package. In particular, upon `pip install .` the various scripts (`generate_tilesets`, `train_model`, etc.) become executable as console scripts.