### PR TITLE
Update README.md for quarry example

### DIFF
--- a/examples/quarry-detection/README.md
+++ b/examples/quarry-detection/README.md
@@ -14,11 +14,9 @@ It consists of the following elements:
 - a data preparation script (`prepare_data.py`) producing the files to be used as input to the `generate_tilesets.py`script.
 - a results post-processing script (`filter_prediction.py`) filtering the predictions, produced from `make_prediction.py`script, to the final shapefile 
 
-After creating and a new environment in python 3.8, the end-to-end workflow can be run by issuing the following list of commands, straight from this folder:
+In the provided Docker container, the end-to-end workflow can be run by issuing the following list of commands, straight from this folder:
 
 ```bash
-$ sudo apt-get install -y python3-gdal gdal-bin libgdal-dev gcc g++ python3.8-dev
-$ pip install -r ../../requirements.txt
 $ python3 prepare_data.py config_trne.yaml
 $ stdl-objdet generate_tilesets config_trne.yaml
 $ stdl-objdet train_model config_trne.yaml

--- a/examples/quarry-detection/README.md
+++ b/examples/quarry-detection/README.md
@@ -20,13 +20,13 @@ After creating and a new environment in python 3.8, the end-to-end workflow can 
 $ sudo apt-get install -y python3-gdal gdal-bin libgdal-dev gcc g++ python3.8-dev
 $ pip install -r ../../requirements.txt
 $ python3 prepare_data.py config_trne.yaml
-$ python3 ../../scripts/generate_tilesets.py config_trne.yaml
-$ python3 ../../scripts/train_model.py config_trne.yaml
-$ python3 ../../scripts/make_predictions.py config_trne.yaml
-$ python3 ../../scripts/assess_predictions.py config_trne.yaml
+$ stdl-objdet generate_tilesets config_trne.yaml
+$ stdl-objdet train_model config_trne.yaml
+$ stdl-objdet make_predictions config_trne.yaml
+$ stdl-objdet assess_predictions config_trne.yaml
 $ python3 prepare_data.py config_prd.yaml
-$ python3 ../../scripts/generate_tilesets.py config_prd.yaml
-$ python3 ../../scripts/make_predictions.py config_prd.yaml
+$ stdl-objdet generate_tilesets config_prd.yaml
+$ stdl-objdet make_predictions config_prd.yaml
 $ python3 filter_detection.py config_prd.yaml
 ```
 


### PR DESCRIPTION
I have updated the README.md file of the **quarry detection** example by replacing the relative paths to object detector scripts with the function `stdl-objdet <script name>`.