### PR TITLE
Ch/update mes example

### DIFF
--- a/examples/mineral-extract-sites-detection/README.md
+++ b/examples/mineral-extract-sites-detection/README.md
@@ -19,7 +19,7 @@ The workflow can be run end-to-end by issuing the following list of commands, fr
 ```
 $ sudo chown -R 65534:65534 examples
 $ docker compose run --rm -it stdl-objdet
-nobody@<id>:/app# cd examples/mineral-extract-site-detection
+nobody@<id>:/app# cd examples/mineral-extract-site-detection/
 nobody@<id>:/app# python prepare_data.py config_trne.yaml
 nobody@<id>:/app# stdl-objdet generate_tilesets config_trne.yaml
 nobody@<id>:/app# stdl-objdet train_model config_trne.yaml

--- a/examples/mineral-extract-sites-detection/README.md
+++ b/examples/mineral-extract-sites-detection/README.md
@@ -19,7 +19,7 @@ The workflow can be run end-to-end by issuing the following list of commands, fr
 ```
 $ sudo chown -R 65534:65534 examples
 $ docker compose run --rm -it stdl-objdet
-nobody@<id>:/app# cd examples/mineral-extract-site-detection/
+nobody@<id>:/app# cd examples/mineral-extract-sites-detection/
 nobody@<id>:/app# python prepare_data.py config_trne.yaml
 nobody@<id>:/app# stdl-objdet generate_tilesets config_trne.yaml
 nobody@<id>:/app# stdl-objdet train_model config_trne.yaml

--- a/examples/mineral-extract-sites-detection/config_det.yaml
+++ b/examples/mineral-extract-sites-detection/config_det.yaml
@@ -51,7 +51,7 @@ make_detections.py:
     enabled: True
     epsilon: 2.0        # cf. https://rdp.readthedocs.io/en/latest/
   score_lower_threshold: 0.3
-  remove_det_overlap: False  # if several detections overlap (IoU > 0.5), only the one with the highest confidence score is retained
+  remove_det_overlap: False  # if several detections overlap (IoU > 0.5), only the one with the highest confidence score is retained. Not recommended for use with a single class.
 
 # 4-Filtering and merging detection polygons
 filter_detections.py:

--- a/examples/mineral-extract-sites-detection/config_det.yaml
+++ b/examples/mineral-extract-sites-detection/config_det.yaml
@@ -7,7 +7,7 @@ prepare_data.py:
   srs: "EPSG:2056"                       # Projection of the input file
   datasets:
     shapefile: ./data/AoI/AoI_2020.shp
-  output_folder: ./output/output_det
+  output_folder: ./output/det/
   zoom_level: 16   
 
 # 2-Fetch of tiles (online server) and split into 3 datasets: train, test, validation
@@ -17,11 +17,11 @@ generate_tilesets.py:
     nb_tiles_max: 5000
   working_directory: output
   datasets:
-    aoi_tiles: output_det/tiles.geojson
+    aoi_tiles: det/tiles.geojson
     image_source:
       type: XYZ     # supported values: 1. MIL = Map Image Layer 2. WMS 3. XYZ 4. FOLDER
       location: https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage-product/default/2020/3857/{z}/{x}/{y}.jpeg
-  output_folder: output_det
+  output_folder: det/
   tile_size: 256    # per side, in pixels
   overwrite: False
   n_jobs: 10
@@ -34,18 +34,18 @@ generate_tilesets.py:
     license:
       name: Unknown
       url:
-    categories_file: output_trne/category_ids.json
+    categories_file: trne/category_ids.json
 
 # 3-Object detection by inference with the optimised trained model
 make_detections.py:
-  working_directory: ./output/output_det
+  working_directory: ./output/det/
   log_subfolder: logs
   sample_tagged_img_subfolder: sample_tagged_images
   COCO_files:           # relative paths, w/ respect to the working_folder
     oth: COCO_oth.json
   detectron2_config_file: ../../detectron2_config_dqry.yaml # path relative to the working_folder
   model_weights:
-    pth_file: ../output_trne/logs/model_final.pth # trained model minimising the validation loss curve, monitor the training process via tensorboard (tensorboard --logdir </logs>) 
+    pth_file: ../trne/logs/model_final.pth # trained model minimising the validation loss curve, monitor the training process via tensorboard (tensorboard --logdir </logs>) 
   image_metadata_json: img_metadata.json
   rdp_simplification:   # rdp = Ramer-Douglas-Peucker
     enabled: True
@@ -56,11 +56,11 @@ make_detections.py:
 # 4-Filtering and merging detection polygons
 filter_detections.py:
   year: 2020
-  detections: ./output/output_det/oth_detections_at_0dot3_threshold.gpkg
+  detections: ./output/det/oth_detections_at_0dot3_threshold.gpkg
   shapefile: ./data/AoI/AoI_2020.shp
   dem: ./data/DEM/switzerland_dem_EPSG2056.tif
   elevation: 1200.0   # m, altitude threshold
   score: 0.95         # detection score (from 0 to 1) provided by detectron2
   distance: 10        # m, distance use as a buffer to merge close polygons (likely to belong to the same object) together
   area: 5000.0        # m2, area threshold under which polygons are discarded
-  output: ./output/output_det/oth_detections_at_0dot3_threshold_year-{year}_score-{score}_area-{area}_elevation-{elevation}_distance-{distance}.geojson
+  output: ./output/det/oth_detections_at_0dot3_threshold_year-{year}_score-{score}_area-{area}_elevation-{elevation}_distance-{distance}.geojson

--- a/examples/mineral-extract-sites-detection/config_trne.yaml
+++ b/examples/mineral-extract-sites-detection/config_trne.yaml
@@ -7,7 +7,7 @@ prepare_data.py:
     # empty_tiles_aoi: ./data/AoI/<SHPFILE>                      # AOI in which additional empty tiles can be selected. Only one 'empty_tiles' option can be selected  
     # empty_tiles_year: 2020                                       # If "empty_tiles_aoi" selected then provide a year. Choice: (1) numeric (i.e. 2020), (2) [year1, year2] (random selection of a year within a given year range) 
     # empty_tiles_shp: .data/empty_tiles/<SHPFILE>                 # Provided shapefile of selected empty tiles. Only one 'empty_tiles' option can be selected  
-  output_folder: ./output/output_trne
+  output_folder: ./output/trne/
   zoom_level: 16
 
 # Fetch of tiles and split into 3 datasets: train, test, validation
@@ -17,10 +17,10 @@ generate_tilesets.py:
     nb_tiles_max: 5000
   working_directory: output
   datasets:
-    aoi_tiles: output_trne/tiles.geojson
-    ground_truth_labels: output_trne/labels.geojson
+    aoi_tiles: trne/tiles.geojson
+    ground_truth_labels: trne/labels.geojson
     # fp_labels:
-    #   fp_shp: output_trne/FP.geojson 
+    #   fp_shp: trne/FP.geojson 
     #   frac_trn: 0.7        # fraction of fp tiles to add to the trn dataset, then the remaining tiles will be split in 2 and added to tst and val datasets                          
     image_source:
       type: XYZ                             # supported values: 1. MIL = Map Image Layer 2. WMS 3. XYZ 4. FOLDER
@@ -30,7 +30,7 @@ generate_tilesets.py:
   #   tiles_frac: 0.5       # fraction (relative to the number of tiles intersecting labels) of empty tiles to add
   #   frac_trn: 0.7         # fraction of empty tiles to add to the trn dataset, then the remaining tiles will be split in 2 and added to tst and val datasets
   #   keep_oth_tiles: False # keep tiles in oth dataset not intersecting oth labels
-  output_folder: output_trne
+  output_folder: trne/
   tile_size: 256          # per side, in pixels
   seed: 42
   overwrite: True
@@ -42,12 +42,12 @@ generate_tilesets.py:
     contributor: swisstopo
     url: https://swisstopo.ch
     license:
-      name: Unknown
-      url:
+      name: unknown
+      url: unknown
 
 # Train the model with the detectron2 algorithm
 train_model.py:
-  working_directory: ./output/output_trne
+  working_directory: ./output/trne/
   log_subfolder: logs
   sample_tagged_img_subfolder: sample_tagged_images
   COCO_files: # relative paths, w/ respect to the working_folder
@@ -60,7 +60,7 @@ train_model.py:
 
 # Object detection with the optimised trained model
 make_detections.py:
-  working_directory: ./output/output_trne
+  working_directory: ./output/trne/
   log_subfolder: logs
   sample_tagged_img_subfolder: sample_tagged_images
   COCO_files:           # relative paths, w/ respect to the working_folder
@@ -79,7 +79,7 @@ make_detections.py:
     
 # Evaluate the quality of the detections for the different datasets by calculating metrics
 assess_detections.py:
-  working_directory: ./output/output_trne
+  working_directory: ./output/trne/
   datasets:
     ground_truth_labels: labels.geojson
     image_metadata_json: img_metadata.json
@@ -92,4 +92,4 @@ assess_detections.py:
   output_folder: .
   iou_threshold: 0.1
   area_threshold: 50       # area under which the polygons are discarded from assessment
-  metrics_method: micro-average   # 1: macro-average ; 3: macro-weighted-average ; 2: micro-average
+  metrics_method: macro-average   # 1: macro-average ; 3: macro-weighted-average ; 2: micro-average

--- a/examples/mineral-extract-sites-detection/config_trne.yaml
+++ b/examples/mineral-extract-sites-detection/config_trne.yaml
@@ -75,7 +75,7 @@ make_detections.py:
     enabled: True
     epsilon: 2.0        # cf. https://rdp.readthedocs.io/en/latest/
   score_lower_threshold: 0.05
-  remove_det_overlap: False  # if several detections overlap (IoU > 0.5), only the one with the highest confidence score is retained
+  remove_det_overlap: False  # if several detections overlap (IoU > 0.5), only the one with the highest confidence score is retained. Not recommended for use with a single class.
     
 # Evaluate the quality of the detections for the different datasets by calculating metrics
 assess_detections.py:

--- a/scripts/generate_tilesets.py
+++ b/scripts/generate_tilesets.py
@@ -654,7 +654,7 @@ def main(cfg_file_path):
 
         # remove tiles including at least one "oth" label (if applicable)
         if OTH_LABELS:
-            oth_tiles_to_remove_gdf, _ = intersect_labels_with_aoi(gt_tiles_gdf, oth_labels_gdf)
+            oth_tiles_to_remove_gdf, _ = intersect_labels_with_aoi(gt_tiles_gdf[['id', 'geometry']], oth_labels_gdf)
             gt_tiles_gdf = gt_tiles_gdf[~gt_tiles_gdf.id.astype(str).isin(oth_tiles_to_remove_gdf.id.astype(str))].copy()
             del oth_tiles_to_remove_gdf
 


### PR DESCRIPTION
I've noticed a typo in the README of the MES example and an error occurred when running the GE swimming pool example.
For the latter, I get the following metrics:

```
2025-01-20 09:55:43 - INFO - Tagging detections with threshold = 0.60, which maximizes the f1-score on the val dataset.
2025-01-20 09:55:43 - INFO - Method to compute the metrics = micro-average
2025-01-20 09:55:55 - INFO - Dataset = trn => precision = 0.945, recall = 0.810, f1 = 0.872
2025-01-20 09:55:57 - INFO - Dataset = val => precision = 0.926, recall = 0.762, f1 = 0.836
2025-01-20 09:55:59 - INFO - Dataset = tst => precision = 0.910, recall = 0.782, f1 = 0.841
2025-01-20 09:56:03 - INFO - Dataset = oth => precision = 0.427, recall = 0.553, f1 = 0.482
```

Is this what we used to get (I don't remember)? In particular, the other metrics are much lower than the others.